### PR TITLE
Request application of insets on attach

### DIFF
--- a/ViewPager2/app/src/main/java/androidx/viewpager2/integration/testapp/EdgeToEdgeUtils.kt
+++ b/ViewPager2/app/src/main/java/androidx/viewpager2/integration/testapp/EdgeToEdgeUtils.kt
@@ -24,6 +24,8 @@ fun View.addSystemWindowInsetToPadding(
 
         insets
     }
+
+    requestApplyInsetsOnAttach()
 }
 
 fun View.addSystemWindowInsetToMargin(
@@ -45,6 +47,15 @@ fun View.addSystemWindowInsetToMargin(
 
         insets
     }
+
+    requestApplyInsetsOnAttach()
+}
+
+private fun View.requestApplyInsetsOnAttach() {
+    addOnAttachStateChangeListener(object : View.OnAttachStateChangeListener {
+        override fun onViewDetachedFromWindow(v: View) {}
+        override fun onViewAttachedToWindow(v: View) = v.requestApplyInsets()
+    })
 }
 
 fun View.goEdgeToEdge() {


### PR DESCRIPTION
When a view is attached that wants to apply system window insets,
request application of those insets. This solves the case where the
insets have already been changed before the view was attached.